### PR TITLE
fix bp list / bp search etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "package:release:win32": "env-cmd electron-builder build --win --ia32 -c.nsis.artifactName=\"PRS-ATM-1.0.11-ia32.exe\" --publish never",
     "postinstall": "yarn build && electron-builder install-app-deps && yarn cross-env NODE_ENV=development webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.babel.js && opencollective-postinstall && yarn-deduplicate yarn.lock",
     "start": "node -r @babel/register ./.erb/scripts/CheckPortInUse.js && concurrently \"yarn start:main\" \"cross-env yarn start:renderer\"",
-    "start:main": "export NODE_ENV=development && electron .",
+    "start:main": "cross-env NODE_ENV=development electron .",
     "start:renderer": "cross-env NODE_ENV=development webpack serve --config ./.erb/configs/webpack.config.renderer.dev.babel.js"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "postcss-loader": "^3.0.0",
     "prettier": "^2.0.5",
-    "prs-atm": "^4.4.38",
+    "prs-atm": "^5.0.6",
     "react-test-renderer": "^17.0.1",
     "regenerator-runtime": "^0.13.5",
     "rimraf": "^3.0.0",

--- a/src/layouts/Preload/index.tsx
+++ b/src/layouts/Preload/index.tsx
@@ -23,19 +23,6 @@ export default observer(() => {
 
   React.useEffect(() => {
     (async () => {
-      const fetchProducer = async () => {
-        const resp: any = await PrsAtm.fetch({
-          actions: ['producer', 'getAll'],
-        });
-        const producer = resp.rows.find((row: any) => {
-          return accountStore.permissionKeys.includes(row.producer_key);
-        });
-        if (producer) {
-          accountStore.setProducer(producer);
-        }
-        accountStore.setIsFetchedProducer(true);
-      };
-
       if (isLogin) {
         try {
           const fetchAccount = async () => {
@@ -74,7 +61,6 @@ export default observer(() => {
 
           fetchPools();
           await Promise.all([fetchAccount(), fetchBalance()]);
-          await fetchProducer();
         } catch (err) {
           console.log(err.message);
           confirmDialogStore.show({

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -12,9 +12,8 @@ export default observer(() => {
   const { accountStore } = useStore();
   const {
     isLogin,
-    isFetchedProducer,
+    account,
     isRunningProducer,
-    producer,
   } = accountStore;
   const history = useHistory();
   const state = useLocalStore(() => ({
@@ -32,7 +31,7 @@ export default observer(() => {
   return (
     <Page
       title="我的账号"
-      loading={!state.isFetchedAccount || !isFetchedProducer}
+      loading={!state.isFetchedAccount}
     >
       <div className="relative">
         <div className="flex">
@@ -41,7 +40,7 @@ export default observer(() => {
           </div>
           <div className="ml-5 w-300-px">
             <Account
-              producer={isRunningProducer ? producer : ({} as IProducer)}
+              producer={account.producer ?? {} as IProducer}
             />
           </div>
         </div>

--- a/src/pages/Producer/index.tsx
+++ b/src/pages/Producer/index.tsx
@@ -79,16 +79,6 @@ export default observer(() => {
       }
       await sleep(800);
       state.isFetched = true;
-      try {
-        const producer = resp.rows.find((row: any) => {
-          return accountStore.permissionKeys.includes(row.producer_key);
-        });
-        if (producer) {
-          accountStore.setProducer(producer);
-        }
-      } catch (err) {
-        console.log(err.message);
-      }
       await sleep(2000);
       state.backToTopEnabled = true;
     })();

--- a/src/pages/Producer/index.tsx
+++ b/src/pages/Producer/index.tsx
@@ -126,6 +126,7 @@ export default observer(() => {
     state.filterKeyword = keyword;
     state.producers = [];
     state.producersLoadDone = false;
+    state.producersLoading = false;
     fetchProducers();
   }, []);
 
@@ -562,7 +563,7 @@ export default observer(() => {
                         </TableCell>
                         <TableCell>{p.unpaid_blocks || '-'}</TableCell>
                         <TableCell>
-                          {index + 1 <= 21 && (
+                          {('priority' in p ? p.priority : index + 1) <= 21 && (
                             <Tooltip
                               placement="top"
                               title="排名前21自动成为出块节点"

--- a/src/pages/Producer/index.tsx
+++ b/src/pages/Producer/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { reaction } from 'mobx';
 import { observer, useLocalStore } from 'mobx-react-lite';
 import Page from 'components/Page';
 import {
@@ -24,6 +25,7 @@ import BackToTop from 'components/BackToTop';
 import { MdInfo, MdSearch } from 'react-icons/md';
 import SearchInput from 'components/SearchInput';
 import Fade from '@material-ui/core/Fade';
+import Loading from 'components/Loading';
 
 export default observer(() => {
   const {
@@ -36,8 +38,12 @@ export default observer(() => {
   const { account, isLogin } = accountStore;
   const state = useLocalStore(() => ({
     voteMode: false,
-    isFetched: false,
+    // isFetched: false,
     producers: [] as IProducer[],
+    producersLoading: false,
+    producersLoadDone: false,
+    nextBpName: null as null | string,
+    loadingInView: false,
     filterKeyword: '',
     showSearch: false,
     backToTopEnabled: false,
@@ -58,35 +64,103 @@ export default observer(() => {
     },
   }));
 
-  const fetchProducers = React.useCallback(() => {
-    (async () => {
-      const resp: any = await PrsAtm.fetch({
-        actions: ['producer', 'getAll'],
+  const loadingBox = React.useRef<HTMLDivElement>(null);
+
+  const fetchProducers = React.useCallback(async () => {
+    if (state.producersLoading || state.producersLoadDone) {
+      return;
+    }
+    const limit = 20;
+    state.producersLoading = true;
+    const resp: any = state.filterKeyword
+      ? await PrsAtm.fetch({
+        actions: ['ballot', 'queryProducer'],
+        args: [state.filterKeyword],
+      })
+      : await PrsAtm.fetch({
+        actions: ['producer', 'queryByRange'],
+        args: [
+          state.nextBpName,
+          limit,
+        ],
       });
-      const derivedProducers: any = resp.rows.map((row: any) => {
-        row.total_votes = parseInt(row.total_votes, 10);
-        return row;
+
+    if (state.filterKeyword) {
+      state.producersLoadDone = true;
+    } else {
+      state.nextBpName = resp.more;
+      state.producersLoadDone = resp.rows.length < limit || !resp.more;
+    }
+
+    const derivedProducers: any = resp.rows.map((row: any) => {
+      row.total_votes = parseInt(row.total_votes, 10);
+      return row;
+    });
+
+    state.producers = [
+      ...state.producers,
+      ...derivedProducers,
+    ];
+
+    if (accountStore.isLogin) {
+      const ballotResult: any = await PrsAtm.fetch({
+        actions: ['ballot', 'queryByOwner'],
+        args: [account.account_name],
       });
-      state.producers = derivedProducers;
-      if (accountStore.isLogin) {
-        const ballotResult: any = await PrsAtm.fetch({
-          actions: ['ballot', 'queryByOwner'],
-          args: [account.account_name],
-        });
-        for (const owner of ballotResult.producers) {
-          state.votedSet.add(owner);
-        }
+      for (const owner of ballotResult.producers) {
+        state.votedSet.add(owner);
       }
-      await sleep(800);
-      state.isFetched = true;
-      await sleep(2000);
-      state.backToTopEnabled = true;
-    })();
+    }
+    await sleep(2000);
+    state.producersLoading = false;
+    state.backToTopEnabled = true;
+  }, []);
+
+  const handleScroll = React.useCallback(() => {
+    if (state.loadingInView) {
+      fetchProducers();
+    }
+  }, []);
+
+  const handleSearch = React.useCallback((keyword: string) => {
+    state.filterKeyword = keyword;
+    state.producers = [];
+    state.producersLoadDone = false;
+    fetchProducers();
   }, []);
 
   React.useEffect(() => {
     fetchProducers();
-  }, [fetchProducers, account]);
+
+    const accountReactionDispose = reaction(
+      () => accountStore.account,
+      () => {
+        state.producers = [];
+        state.producersLoading = false;
+        state.producersLoadDone = false;
+        fetchProducers();
+      }
+    )
+
+    const io = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        state.loadingInView = entry.intersectionRatio > 0.1
+        if (state.loadingInView) {
+          fetchProducers();
+        }
+      }
+    }, { threshold: 0.1 });
+
+    if (loadingBox.current) {
+      io.observe(loadingBox.current);
+    }
+
+    return () => {
+      accountReactionDispose();
+      io.disconnect();
+    }
+  }, []);
 
   const Head = () => {
     return (
@@ -297,7 +371,7 @@ export default observer(() => {
   };
 
   return (
-    <Page title="节点投票" loading={!state.isFetched}>
+    <Page title="节点投票" loading={!state.producers && state.producersLoading}>
       <div className="px-6 py-6 bg-white rounded-12 relative">
         <div className="absolute top-0 right-0 -mt-12 flex items-center h-8">
           {!state.showSearch && (
@@ -328,9 +402,7 @@ export default observer(() => {
                   className="w-46"
                   placeholder="输入节点名称"
                   size="small"
-                  search={(keyword: string) => {
-                    state.filterKeyword = keyword;
-                  }}
+                  search={handleSearch}
                 />
               </div>
             </Fade>
@@ -407,7 +479,10 @@ export default observer(() => {
             </div>
           )}
         </div>
-        <div className="table-container overflow-y-auto">
+        <div
+          className="table-container overflow-y-auto"
+          onScroll={handleScroll}
+        >
           <Paper>
             <Table>
               <Head />
@@ -419,7 +494,7 @@ export default observer(() => {
                     }
                     return p.owner.includes(state.filterKeyword);
                   })
-                  .map((p, index) => {
+                  .map((p: any, index) => {
                     if (!p.is_active) {
                       return null;
                     }
@@ -428,7 +503,7 @@ export default observer(() => {
                         key={p.last_claim_time + index}
                         className={classNames({
                           'cursor-pointer active-hover': state.voteMode,
-                          'border-b-4 border-indigo-300': index + 1 === 21,
+                          'border-b-4 border-indigo-300': !state.filterKeyword && index + 1 === 21,
                         })}
                         onClick={() => {
                           if (state.addVotedSet.has(p.owner)) {
@@ -470,7 +545,7 @@ export default observer(() => {
                         )}
                         <TableCell>
                           <div className="h-6 flex items-center">
-                            {index + 1}
+                            {'priority' in p ? p.priority : index + 1}
                           </div>
                         </TableCell>
                         <TableCell>
@@ -514,6 +589,19 @@ export default observer(() => {
                   })}
               </TableBody>
             </Table>
+            <div
+              className={classNames(
+                'flex justify-center items-center',
+                !state.producersLoadDone && 'py-2'
+              )}
+              ref={loadingBox}
+            >
+              {state.producersLoading && (
+                <div className="mb-8 mt-16">
+                  <Loading size={36} />
+                </div>
+              )}
+            </div>
           </Paper>
         </div>
         {state.backToTopEnabled && (

--- a/src/pages/Swap/Exchanger.tsx
+++ b/src/pages/Swap/Exchanger.tsx
@@ -207,7 +207,7 @@ export default observer(() => {
         state.toAmount = '';
         state.showDryRunResult = false;
         confirmDialogStore.show({
-          content: `兑换成功，${state.toCurrency} 即将转入你的 Mixin 钱包，可前往 Mixin 查看`,
+          content: `支付成功后，${state.toCurrency} CNB 将转入你的 mixin 钱包，可前往 mixin 查看`,
           okText: '我知道了',
           ok: () => confirmDialogStore.hide(),
           cancelDisabled: true,

--- a/src/pages/Swap/Exchanger.tsx
+++ b/src/pages/Swap/Exchanger.tsx
@@ -207,7 +207,7 @@ export default observer(() => {
         state.toAmount = '';
         state.showDryRunResult = false;
         confirmDialogStore.show({
-          content: `支付成功后，${state.toCurrency} CNB 将转入你的 mixin 钱包，可前往 mixin 查看`,
+          content: `支付成功后，${state.toCurrency} 将转入你的 Mixin 钱包，可前往 Mixin 查看`,
           okText: '我知道了',
           ok: () => confirmDialogStore.hide(),
           cancelDisabled: true,

--- a/src/store/account.ts
+++ b/src/store/account.ts
@@ -67,6 +67,7 @@ export interface IAccount {
     ram_bytes: number;
   };
   voter_info: any;
+  producer: IProducer;
 }
 
 export function createAccountStore() {
@@ -74,19 +75,17 @@ export function createAccountStore() {
     isFetched: false,
     account: (store.get('account') || {}) as IAccount,
     publicKey: (store.get('publickey') as string) || '',
-    producer: {} as IProducer,
-    isFetchedProducer: false,
     get isRunningProducer() {
-      if (isEmpty(this.producer)) {
+      if (isEmpty(this.account.producer)) {
         return false;
       }
       return (
-        larger(this.producer.total_votes, 0) ||
-        larger(this.producer.unpaid_blocks, 0)
+        larger(this.account.producer.total_votes, 0) ||
+        larger(this.account.producer.unpaid_blocks, 0)
       );
     },
     get isProducer() {
-      return !isEmpty(this.producer);
+      return !isEmpty(this.account.producer);
     },
     get isLogin() {
       return !isEmpty(this.account) && !!this.publicKey;
@@ -149,7 +148,6 @@ export function createAccountStore() {
         encryptedPasswordStore.delete(this.publicKey);
       }
       this.account = {} as IAccount;
-      this.producer = {} as IProducer;
       store.set('account', {});
       store.set('publickey', '');
     },
@@ -189,12 +187,6 @@ export function createAccountStore() {
         encryptionKey: this.publicKey,
       });
       return encryptedPasswordStore.has(this.publicKey);
-    },
-    setProducer(producer: IProducer) {
-      this.producer = producer;
-    },
-    setIsFetchedProducer(value: boolean) {
-      this.isFetchedProducer = value;
     },
   };
 }

--- a/src/types/styled-jsx.d.ts
+++ b/src/types/styled-jsx.d.ts
@@ -1,0 +1,8 @@
+import 'react';
+
+declare module 'react' {
+  interface StyleHTMLAttributes<T> extends React.HTMLAttributes<T> {
+    jsx?: boolean;
+    global?: boolean;
+  }
+}

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -34,6 +34,11 @@ debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
+electron-log@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.3.1.tgz#1405fef9d4e6964a5fdb8790a69163aa237ffe91"
+  integrity sha512-S/0CMjYjgyWUsZ3d27VvErPaI5W4oILp4jfeCuN4DhDqrJW6jKRUD2PxFfTdeZEIjM7+fttGg7A61rPcAcZC1w==
+
 electron-updater@^4.3.5:
   version "4.3.5"
   resolved "https://registry.npm.taobao.org/electron-updater/download/electron-updater-4.3.5.tgz#4fb36f593a031c87ea07ee141c9f064d5deffb15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8726,10 +8726,10 @@ prr@~1.0.1:
   resolved "https://registry.npm.taobao.org/prr/download/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
-prs-atm@^4.4.38:
-  version "4.4.38"
-  resolved "https://registry.npm.taobao.org/prs-atm/download/prs-atm-4.4.38.tgz#bb752d0bb990a0092c86c7a52e65546526c0bef0"
-  integrity sha1-u3UtC7mQoAkshselLmVUZSbAvvA=
+prs-atm@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.npm.taobao.org/prs-atm/download/prs-atm-5.0.6.tgz#f63293de1aed24b011e53e0e46b574c56e315c60"
+  integrity sha1-9jKT3hrtJLAR5T4ORrV0xW4xXGA=
   dependencies:
     readline-sync "^1.4.10"
     table "^6.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,9 +1344,9 @@
   resolved "https://registry.npm.taobao.org/@types/debug/download/@types/debug-4.1.5.tgz?cache=0&sync_timestamp=1605052780195&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fdebug%2Fdownload%2F%40types%2Fdebug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha1-sU76iFK3do2JiQZhPCP2iHE+As0=
 
-"@types/enzyme-adapter-react-16@^1.0.6":
+"@types/enzyme-adapter-react-16@^1.0.5":
   version "1.0.6"
-  resolved "https://registry.npm.taobao.org/@types/enzyme-adapter-react-16/download/@types/enzyme-adapter-react-16-1.0.6.tgz#8aca7ae2fd6c7137d869b6616e696d21bb8b0cec"
+  resolved "https://registry.npm.taobao.org/@types/enzyme-adapter-react-16/download/@types/enzyme-adapter-react-16-1.0.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fenzyme-adapter-react-16%2Fdownload%2F%40types%2Fenzyme-adapter-react-16-1.0.6.tgz#8aca7ae2fd6c7137d869b6616e696d21bb8b0cec"
   integrity sha1-isp64v1scTfYabZhbmltIbuLDOw=
   dependencies:
     "@types/enzyme" "*"
@@ -1536,15 +1536,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.0"
-  resolved "https://registry.npm.taobao.org/@types/react/download/@types/react-17.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Freact%2Fdownload%2F%40types%2Freact-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
-  integrity sha1-WvPrf60oBwkvAEahMCt4I+J5Gbg=
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
-
-"@types/react@^16", "@types/react@^16.9.44":
+"@types/react@*", "@types/react@^16", "@types/react@^16.9.44":
   version "16.14.2"
   resolved "https://registry.npm.taobao.org/@types/react/download/@types/react-16.14.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Freact%2Fdownload%2F%40types%2Freact-16.14.2.tgz#85dcc0947d0645349923c04ccef6018a1ab7538c"
   integrity sha1-hdzAlH0GRTSZI8BMzvYBihq3U4w=
@@ -1566,7 +1558,7 @@
 
 "@types/styled-jsx@^2.2.8":
   version "2.2.8"
-  resolved "https://registry.npm.taobao.org/@types/styled-jsx/download/@types/styled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
+  resolved "https://registry.npm.taobao.org/@types/styled-jsx/download/@types/styled-jsx-2.2.8.tgz?cache=0&sync_timestamp=1613385518034&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fstyled-jsx%2Fdownload%2F%40types%2Fstyled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
   integrity sha1-tQ0T2KPDQDYoLWUZRVTPGGurcjQ=
   dependencies:
     "@types/react" "*"


### PR DESCRIPTION
修改：

1. 首页我的信息已经使用account接口的数据
2. bp列表支持分页，采用滑倒底自动加载下一页，目前1页20项
3. 已完成搜索，使用了搜索结果内的排名数据，修复了出块类型不正确的问题
4. 修改swap支付成功的提示，提示到mixin查看
5. 升级prs-atm到5.0.6